### PR TITLE
Fix/steamclient.so

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -87,7 +87,7 @@ jobs:
           push: ${{ github.ref_type == 'tag' }}
           build-args: |
             APP_ID=2239530
-            SAVEGAME_LOCATION=/root/.local/share/American Truck Simulator/
+            SAVEGAME_LOCATION=/home/steam/.local/share/American Truck Simulator/
             EXECUTABLE=/app/bin/linux_x64/amtrucks_server
             DEFAULT_PACKAGES=default_packages/ats
           platforms: linux/amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,10 @@ RUN apt-get update && apt-get install -y python3
 RUN mkdir -p "${SAVEGAME_LOCATION}" \
     && chown steam:steam -R "${SAVEGAME_LOCATION}" \
     && mkdir -p /default_packages \
-    && mkdir -p /home/steam/.steam/sdk64 \
+    && mkdir -p /home/steam/.steam/sdk64 /home/steam/.steam/sdk32 \
     && ln -s /home/steam/steamcmd/linux64/steamclient.so /home/steam/.steam/sdk64/steamclient.so \
-    && chown steam:steam -R /home/steam/.steam/sdk64
+    && ln -s /home/steam/steamcmd/linux32/steamclient.so /home/steam/.steam/sdk32/steamclient.so \
+    && chown steam:steam -R /home/steam/.steam/sdk64 /home/steam/.steam/sdk32
 
 COPY ets_server_entrypoint.py /ets_server_entrypoint.py
 COPY entrypoint.sh /entrypoint

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN mkdir -p "${SAVEGAME_LOCATION}" \
     && mkdir -p /default_packages \
     && mkdir -p /home/steam/.steam/sdk64 \
     && ln -s /home/steam/steamcmd/linux64/steamclient.so /home/steam/.steam/sdk64/steamclient.so \
-    && chown steam:steam -R /home/steam/.steam/sdk64 /home/steam/.steam/sdk32
+    && chown steam:steam -R /home/steam/.steam/sdk64
 
 COPY ets_server_entrypoint.py /ets_server_entrypoint.py
 COPY entrypoint.sh /entrypoint

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,8 @@ RUN apt-get update && apt-get install -y python3
 RUN mkdir -p "${SAVEGAME_LOCATION}" \
     && chown steam:steam -R "${SAVEGAME_LOCATION}" \
     && mkdir -p /default_packages \
-    && mkdir -p /home/steam/.steam/sdk64 /home/steam/.steam/sdk32 \
+    && mkdir -p /home/steam/.steam/sdk64 \
     && ln -s /home/steam/steamcmd/linux64/steamclient.so /home/steam/.steam/sdk64/steamclient.so \
-    && ln -s /home/steam/steamcmd/linux32/steamclient.so /home/steam/.steam/sdk32/steamclient.so \
     && chown steam:steam -R /home/steam/.steam/sdk64 /home/steam/.steam/sdk32
 
 COPY ets_server_entrypoint.py /ets_server_entrypoint.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM steamcmd/steamcmd:ubuntu
+FROM cm2network/steamcmd:steam
 
 ARG APP_ID=1948160
-ARG SAVEGAME_LOCATION="/root/.local/share/Euro Truck Simulator 2/"
+ARG SAVEGAME_LOCATION="/home/steam/.local/share/Euro Truck Simulator 2/"
 ARG EXECUTABLE="/app/bin/linux_x64/eurotrucks2_server"
 ARG DEFAULT_PACKAGES="default_packages/ets2"
 
@@ -13,10 +13,18 @@ ENV APP_ID=${APP_ID}
 
 WORKDIR /app
 
+# Install python for init script
+USER root
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y python3 \
-    && mkdir -p "${SAVEGAME_LOCATION}" \
-    && mkdir -p /default_packages
+RUN apt-get update && apt-get install -y python3
+
+# Create required dirs and symlinks
+RUN mkdir -p "${SAVEGAME_LOCATION}" \
+    && chown steam:steam -R "${SAVEGAME_LOCATION}" \
+    && mkdir -p /default_packages \
+    && mkdir -p /home/steam/.steam/sdk64 \
+    && ln -s /home/steam/steamcmd/linux64/steamclient.so /home/steam/.steam/sdk64/steamclient.so \
+    && chown steam:steam -R /home/steam/.steam/sdk64
 
 COPY ets_server_entrypoint.py /ets_server_entrypoint.py
 COPY entrypoint.sh /entrypoint
@@ -25,8 +33,7 @@ RUN chmod +x /entrypoint
 COPY ["${DEFAULT_PACKAGES}/server_packages.dat", "/default_packages/"]
 COPY ["${DEFAULT_PACKAGES}/server_packages.sii", "/default_packages/"]
 
-# needed for ETS server to find steamclient.so
-ENV LD_LIBRARY_PATH='/app/linux64'
+USER steam
 
 ENTRYPOINT [ "/entrypoint" ]
 CMD [ "bash", "-c", "${EXECUTABLE}" ]

--- a/ETS_SERVER_README.md
+++ b/ETS_SERVER_README.md
@@ -61,7 +61,9 @@ Search id is listed when starting dedicated server or in convoy info screen for 
 
 ## 7. Server logon token
 ---
-By default whenever a dedicated server is launched it is using an anonymous account. For such an account non-persistent server id is generated (used for direct search). To avoid this you can acquire a logon token on https://steamcommunity.com/dev/managegameservers (game ownership is required).
+By default whenever a dedicated server is launched it is using an anonymous account. For such an account non-persistent server id is generated (used for direct search). To avoid this you can acquire a logon token on [https://steamcommunity.com/dev/managegameservers](https://steamcommunity.com/dev/managegameservers) (game ownership is required).  
+For ETS use AppID 227300, for ATS use AppID 270880.  
+**Do not use the server AppIDs (1948160, 2239530)!**
 
 
 ## 8. Session moderators

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Stop the server with `docker compose stop` and remove it with `docker compose do
 | Variable Name | Example | Description | Default |
 | ---------------- | ------------------ | ----------------- | ---------- |
 | ETS_SERVER_WRITE_CONFIG | true | Enable/disable automatic config generation from env variables. | true |
-| ETS_SERVER_UPDATE_ON_START | false | Enable/disable update on server start. Will always update on first start to get server files. | false |
+| ETS_SERVER_UPDATE_ON_START | true | Enable/disable update on server start. Will always update on first start to get server files. | true |
 | ETS_SERVER_NAME | My Server | The name of the server. Shown ingame. | Euro Truck Simulator 2 Docker Server |
 | ETS_SERVER_DESCRIPTION | Join me! | The description of the server. Shown ingame. | "" |
 | ETS_SERVER_WELCOME_MESSAGE | Welcome to my server! | The welcome message. Shown ingame. | "" |

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Easy to configure and use!
  - [Environment Variables](#environment-variables)
  - [Custom DLCs/Mods (Untested)](#custom-dlcmods)
  - [Troubleshooting](#troubleshooting)
-   - [Login Error 106](#login-error-106)
    - [Login Error 15](#login-error-15)
+   - [Login Error 106](#login-error-106)
 
 # Running
 ## Minimal example:
@@ -132,14 +132,15 @@ To enable your installed DLCs or mods you need to generate custom `server_packag
 
 # Troubleshooting
 
-## Login Error 106
-Login error 106 indicates that your logon token is invalid.  
-The token will lose validity after some time and you will need to generate a new one.  
+## Login Error 15
+Login error 15 indicates that the token is for the wrong game. Please check that you have not used your ETS token for ATS or similar.  
 
 See [ETS_SERVER_README.md](ETS_SERVER_README.md#7-server-logon-token) to genrate a new token.
 
-## Login Error 15
-Login error 15 indicated that it is for the wrong game. Please check that you have not used your ETS token for ATS or similar.  
+## Login Error 106
+Login error 106 indicates that your logon token is invalid.  
+The token will lose validity after some time and you will need to generate a new one.  
 To check if the token is still valid log into steam in a browser and go to [https://steamcommunity.com/dev/managegameservers](https://steamcommunity.com/dev/managegameservers).  
 If the token has strike through it is no longer valid.  
+
 See [ETS_SERVER_README.md](ETS_SERVER_README.md#7-server-logon-token) to genrate a new token.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Stop the server with `docker compose stop` and remove it with `docker compose do
 | ETS_SERVER_FRIENDS_ONLY | false | Limit server to steam friends??? | false |
 | ETS_SERVER_SHOW_SERVER | true | Show server in public server list? | true |
 | ETS_SERVER_MODERATORS | 208370238402, 2384723894723, 283947923 | List of steam IDs to turn moderatos on join. Moderators can alter the server time. See [Server README](ETS_SERVER_README.md#8-session-moderators) | "" |
-| ETS_SERVER_CONFIG_FILE_PATH | /home/user/ets/server_config.sii | Path to server config file. | /root/.local/share/Euro Truck Simulator 2/server_config.sii |
+| ETS_SERVER_CONFIG_FILE_PATH | /home/user/ets/server_config.sii | Path to server config file. | /home/steam/.local/share/Euro Truck Simulator 2/server_config.sii |
 
 *As you can probably tell, there are some question marks in the descriptions. I'm not sure what the parameters are doing. If you have any clue, please open an [issue](https://github.com/LsHallo/ets2-dedicated-convoy-server/issues) or [pull request](https://github.com/LsHallo/ets2-dedicated-convoy-server/pulls).*
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,15 @@
 This docker container provides the new (as of Dec 2022) dedicated server for ETS2/ATS in a simple and complete package.  
 Easy to configure and use!
 
-[GitHub Repo](https://github.com/LsHallo/ets2-dedicated-convoy-server)
+# Contents
+ - [Running](#running)
+   - [ETS2](#ets2)
+   - [ATS](#ats)
+ - [Environment Variables](#environment-variables)
+ - [Custom DLCs/Mods (Untested)](#custom-dlcmods)
+ - [Troubleshooting](#troubleshooting)
+   - [Login Error 106](#login-error-106)
+   - [Login Error 15](#login-error-15)
 
 # Running
 ## Minimal example:
@@ -121,3 +129,17 @@ To enable your installed DLCs or mods you need to generate custom `server_packag
         - You need to mount `/root/.local/share/Euro Truck Simulator 2` to a local directory using your docker run config.
         - Place the files in the mounted directory. E.g.: `/opt/ets2`
     - Restart your server
+
+# Troubleshooting
+
+## Login Error 106
+Login error 106 indicates that your logon token is invalid.  
+The token will lose validity after some time and you will need to generate a new one.  
+
+See [ETS_SERVER_README.md](ETS_SERVER_README.md#7-server-logon-token) to genrate a new token.
+
+## Login Error 15
+Login error 15 indicated that it is for the wrong game. Please check that you have not used your ETS token for ATS or similar.  
+To check if the token is still valid log into steam in a browser and go to [https://steamcommunity.com/dev/managegameservers](https://steamcommunity.com/dev/managegameservers).  
+If the token has strike through it is no longer valid.  
+See [ETS_SERVER_README.md](ETS_SERVER_README.md#7-server-logon-token) to genrate a new token.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Easy to configure and use!
  - [Troubleshooting](#troubleshooting)
    - [Login Error 15](#login-error-15)
    - [Login Error 106](#login-error-106)
+   - [Can't write config file `server_config.sii`](#cant-write-config-file-server_configsii)
 
 # Running
 ## Minimal example:
@@ -126,16 +127,20 @@ To enable your installed DLCs or mods you need to generate custom `server_packag
 4. Go to your savegames folder again.
     - You should see 2 new files: `server_packages.dat` and `server_packages.sii`
     - Copy the files to your ets2 server data directory (replacing the existing ones)
-        - You need to mount `/root/.local/share/Euro Truck Simulator 2` to a local directory using your docker run config.
+        - You need to mount `/home/steam/.local/share/Euro Truck Simulator 2` to a local directory using your docker run config.
         - Place the files in the mounted directory. E.g.: `/opt/ets2`
     - Restart your server
 
+
+
 # Troubleshooting
+
 
 ## Login Error 15
 Login error 15 indicates that the token is for the wrong game. Please check that you have not used your ETS token for ATS or similar.  
 
 See [ETS_SERVER_README.md](ETS_SERVER_README.md#7-server-logon-token) to genrate a new token.
+
 
 ## Login Error 106
 Login error 106 indicates that your logon token is invalid.  
@@ -144,3 +149,8 @@ To check if the token is still valid log into steam in a browser and go to [http
 If the token has strike through it is no longer valid.  
 
 See [ETS_SERVER_README.md](ETS_SERVER_README.md#7-server-logon-token) to genrate a new token.
+
+
+## Can't write config file `server_config.sii`
+Make sure the mounted folder owner is user id 1000.
+`chown -R 1000:1000 /opt/ets2` (or whereever you have mounted it)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     #  - "27016:27016/udp"
     volumes:
       - "/opt/ets2-server/game-data:/app" # server data
-    #  - "/opt/ets2-server/save-data:/root/.local/share/Euro Truck Simulator 2"  # Only needed when using custom server_packages.sii and server_packages.dat
+    #  - "/opt/ets2-server/save-data:/home/steam/.local/share/Euro Truck Simulator 2"  # Only needed when using custom server_packages.sii and server_packages.dat
     environment:
       - "ETS_SERVER_UPDATE_ON_START=true"
       - "ETS_SERVER_NAME=My Server"
@@ -48,7 +48,7 @@ services:
     #  - "27016:27016/udp"
     volumes:
       - "/opt/ats-server/game-data:/app" # server data
-    #  - "/opt/ats-server/save-data:/root/.local/share/American Truck Simulator" # Only needed when using custom server_packages.sii and server_packages.dat
+    #  - "/opt/ats-server/save-data:/home/steam/.local/share/American Truck Simulator" # Only needed when using custom server_packages.sii and server_packages.dat
     environment:
       - "ETS_SERVER_UPDATE_ON_START=true"
       - "ETS_SERVER_NAME=My Server"

--- a/ets_server_entrypoint.py
+++ b/ets_server_entrypoint.py
@@ -128,7 +128,7 @@ if __name__ == "__main__":
             else:
                 print(f"[ERROR]: Could not write config file ({config_path}). Check file permissions!")
     
-    if is_truthy(os.getenv("ETS_SERVER_UPDATE_ON_START", "false")) or not server_files_exist():
+    if is_truthy(os.getenv("ETS_SERVER_UPDATE_ON_START", "true")) or not server_files_exist():
         print("[INFO]: Updating ETS Server...")
         APP_ID = os.getenv("APP_ID")
         os.system(f"steamcmd +force_install_dir /app +login anonymous +app_update {APP_ID} +quit")

--- a/ets_server_entrypoint.py
+++ b/ets_server_entrypoint.py
@@ -109,7 +109,6 @@ server_config : _nameless.44c.eab0 {{
  show_server: {str(show_server).lower()}
  {moderator_list_generated}
 }}
-
 }}
 """
 
@@ -131,7 +130,7 @@ if __name__ == "__main__":
     if is_truthy(os.getenv("ETS_SERVER_UPDATE_ON_START", "true")) or not server_files_exist():
         print("[INFO]: Updating ETS Server...")
         APP_ID = os.getenv("APP_ID")
-        os.system(f"steamcmd +force_install_dir /app +login anonymous +app_update {APP_ID} +quit")
+        os.system(f"/home/steam/steamcmd/steamcmd.sh +force_install_dir /app +login anonymous +app_update {APP_ID} +quit")
         print("[INFO]: Update done.")
     else:
         print("[INFO]: Skipping server update. To update set 'ETS_SERVER_UPDATE_ON_START=true'.")

--- a/ets_server_entrypoint.py
+++ b/ets_server_entrypoint.py
@@ -118,7 +118,7 @@ server_config : _nameless.44c.eab0 {{
 if __name__ == "__main__":
     if is_truthy(os.getenv("ETS_SERVER_WRITE_CONFIG", "true")):
         config = generate_config()
-        config_path = os.getenv("ETS_SERVER_CONFIG_FILE_PATH", "/root/.local/share/Euro Truck Simulator 2/server_config.sii")
+        config_path = os.getenv("ETS_SERVER_CONFIG_FILE_PATH", "/home/steam/.local/share/Euro Truck Simulator 2/server_config.sii")
         with open(config_path, "w") as f:
             if f.writable():
                 f.write(config)

--- a/ets_server_entrypoint.py
+++ b/ets_server_entrypoint.py
@@ -126,7 +126,7 @@ if __name__ == "__main__":
                 print("[INFO]: Config file written.")
             else:
                 print(f"[ERROR]: Could not write config file ({config_path}). Check file permissions!")
-    
+
     if is_truthy(os.getenv("ETS_SERVER_UPDATE_ON_START", "true")) or not server_files_exist():
         print("[INFO]: Updating ETS Server...")
         APP_ID = os.getenv("APP_ID")


### PR DESCRIPTION
- Use new base image (cm2network/steamcmd:steam) as it seems more officially supported. (https://developer.valvesoftware.com/wiki/SteamCMD#Docker)
- Adjust dockerfile for new image
- Symlink steamclient.so to home dir sdk64 and sdk32 to avoid having to specify LD_LIBRARY_PATH
- Adjust github build pipeline for new image
