### PR TITLE
Changing branches (beta-versions)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -350,3 +350,5 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.toptal.com/developers/gitignore/api/intellij+all,visualstudiocode,python,windows,macos,linux
+
+/docker-compose.override.yml

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Stop the server with `docker compose stop` and remove it with `docker compose do
 | ETS_SERVER_SHOW_SERVER | true | Show server in public server list? | true |
 | ETS_SERVER_MODERATORS | 208370238402, 2384723894723, 283947923 | List of steam IDs to turn moderatos on join. Moderators can alter the server time. See [Server README](ETS_SERVER_README.md#8-session-moderators) | "" |
 | ETS_SERVER_CONFIG_FILE_PATH | /home/user/ets/server_config.sii | Path to server config file. | /home/steam/.local/share/Euro Truck Simulator 2/server_config.sii |
+| ETS_SERVER_BRANCH | temporary_1_47 | Server branch. Allows downgrading to an older version. At SteamDB you'll find available branches for both [ETS2](https://steamdb.info/app/1948160/depots) and [ATS](https://steamdb.info/app/2239530/depots). To return back to the latest public release, use "public" | "" |
 
 *As you can probably tell, there are some question marks in the descriptions. I'm not sure what the parameters are doing. If you have any clue, please open an [issue](https://github.com/LsHallo/ets2-dedicated-convoy-server/issues) or [pull request](https://github.com/LsHallo/ets2-dedicated-convoy-server/pulls).*
 

--- a/ets_server_entrypoint.py
+++ b/ets_server_entrypoint.py
@@ -130,7 +130,8 @@ if __name__ == "__main__":
     if is_truthy(os.getenv("ETS_SERVER_UPDATE_ON_START", "true")) or not server_files_exist():
         print("[INFO]: Updating ETS Server...")
         APP_ID = os.getenv("APP_ID")
-        os.system(f"/home/steam/steamcmd/steamcmd.sh +force_install_dir /app +login anonymous +app_update {APP_ID} +quit")
+        beta_argument = " -beta " + os.getenv("ETS_SERVER_BRANCH") if os.getenv("ETS_SERVER_BRANCH") else ""
+        os.system(f"/home/steam/steamcmd/steamcmd.sh +force_install_dir /app +login anonymous +app_update {APP_ID}{beta_argument} +quit")
         print("[INFO]: Update done.")
     else:
         print("[INFO]: Skipping server update. To update set 'ETS_SERVER_UPDATE_ON_START=true'.")


### PR DESCRIPTION
Thanks for your valuable work!

I play heavily modded ETS2 with my friend, and thus, it takes a long time to update to the latest version. [There is an official way to keep ETS2 at a specific version](https://steamcommunity.com/sharedfiles/filedetails/?id=333180674).

We can use this feature in SteamCMD [by supplying `-beta` argument](https://developer.valvesoftware.com/wiki/SteamCMD#Downloading_an_App).